### PR TITLE
Changed initial message.

### DIFF
--- a/tasks/madge.js
+++ b/tasks/madge.js
@@ -13,7 +13,7 @@ module.exports = function (grunt) {
 
     grunt.registerMultiTask('madge', 'Check for circular dependencies in modules.', function () {
 
-        grunt.log.write('Checking ' + this.filesSrc.join(', ') + '...');
+        grunt.log.write('Checking ' + this.filesSrc.length + ' file(s)...');
 
         var done = this.async();
 


### PR DESCRIPTION
Hi,
it is not needed to explicitly print all file names to console. Madge will do that by running the task in verbose mode (--verbose modifier). It is also user un-friendly in case your project has thousands of files.
Thanks!